### PR TITLE
bugfix/function-scopes

### DIFF
--- a/Interpreter/Interpreter.cs
+++ b/Interpreter/Interpreter.cs
@@ -24,10 +24,11 @@ namespace LSharp.Interpreter
         private Enviroment.Enviroment enviroment = new Enviroment.Enviroment();
         private Dictionary<string, bool> imports = new();
         private readonly Dictionary<Expression, int> locals = new();
-        public Enviroment.Enviroment Globals { get => enviroment; }
+        public Enviroment.Enviroment Globals;
 
         public Interpreter()
         {
+            Globals = enviroment;
             enviroment.Define("clock", new Clock());
         } 
 
@@ -573,14 +574,9 @@ namespace LSharp.Interpreter
         /// <param name="expression">Any valid expression.</param>
         private object lookUpVariable(Token name, Expression expression)
         {
-            int? distance = null;
-            int value;
-            var result = locals.TryGetValue(expression, out value);
-            if (result) distance = value;
-            if (locals.ContainsKey(expression)) distance = locals[expression];
-            if (distance != null)
+            if (locals.TryGetValue(expression, out int distance))
             {
-                return enviroment.GetAt(distance.Value, name.Lexeme);
+                return enviroment.GetAt(distance, name.Lexeme);
             }
             else
             {

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "LSharp": {
       "commandName": "Project",
-      "commandLineArgs": "usingTest.ls"
+      "commandLineArgs": "test3.ls"
     }
   }
 }


### PR DESCRIPTION
# Bugfix
* The `globals` property was previously defined as a `getter` that pointed to the current `environment` of the `interpreter` (said approach led to a interesting issue, since even while looking at global `vars`, the `interpreter` was looking up `vars` from the innermost scope to the outermost one). Now the `globals` property is defined as a copy of the outermost `environment` of the `interpreter`, on its respective `constructor`.