### PR TITLE
Feature/single file exec

### DIFF
--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -2,8 +2,8 @@
 on:
   push:
     branches:
-      # - master
-      - feature/single-file-exec
+      - master
+      #- feature/single-file-exec
 
 jobs:
   build_and_release_project:

--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -41,9 +41,11 @@ jobs:
           cd ${{ github.workspace }}/bin/Release/net6.0
           
           # Zip the runtime folder
-          zip -r lsharp-${{ matrix.tag }}.zip ./linux-x64
-          zip -r lsharp-win10-x64.zip ./win10-x64
+          cd ./linux-x64
+          zip -r lsharp-${{ matrix.tag }}.zip ./publish/
           mv ./lsharp-${{ matrix.tag }}.zip ${{ github.workspace }}
+          cd ../win10-x64
+          zip -r lsharp-win10-x64.zip ./publish/
           mv ./lsharp-win10-x64.zip ${{ github.workspace }}
       - name: Create New Release
         id: create_new_release

--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -44,7 +44,7 @@ jobs:
           cd ./linux-x64
           zip -r lsharp-${{ matrix.tag }}.zip ./publish/
           mv ./lsharp-${{ matrix.tag }}.zip ${{ github.workspace }}
-          cd ../win10-x64
+          cd ./win10-x64
           zip -r lsharp-win10-x64.zip ./publish/
           mv ./lsharp-win10-x64.zip ${{ github.workspace }}
       - name: Create New Release

--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -44,7 +44,7 @@ jobs:
           cd ./linux-x64
           zip -r lsharp-${{ matrix.tag }}.zip ./publish/
           mv ./lsharp-${{ matrix.tag }}.zip ${{ github.workspace }}
-          cd ./win10-x64
+          cd ../win10-x64
           zip -r lsharp-win10-x64.zip ./publish/
           mv ./lsharp-win10-x64.zip ${{ github.workspace }}
       - name: Create New Release

--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Setup Dependencies
         run: dotnet restore
       - name: Build For Linux
-        run: dotnet publish -c Release -r linux-x64 -p PublishReadyToRun=true -p PublishSingleFile=true --self-contained
+        run: dotnet publish -r linux-x64 -c Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --self-contained
       - name: Build For Windows
-        run: dotnet publish -c Release -r win10-x64 -p PublishReadyToRun=true -p PublishSingleFile=true --self-contained
+        run: dotnet publish -r win10-x64 -c Release -p:PublishReadyToRun=true -p:PublishSingleFile=true --self-contained
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}/bin/Release/net6.0

--- a/.github/workflows/lsharp-build-and-release-linux-win.yml
+++ b/.github/workflows/lsharp-build-and-release-linux-win.yml
@@ -2,7 +2,8 @@
 on:
   push:
     branches:
-      - master
+      # - master
+      - feature/single-file-exec
 
 jobs:
   build_and_release_project:
@@ -23,9 +24,9 @@ jobs:
       - name: Setup Dependencies
         run: dotnet restore
       - name: Build For Linux
-        run: dotnet publish --configuration Release --runtime linux-x64 --self-contained
+        run: dotnet publish -c Release -r linux-x64 -p PublishReadyToRun=true -p PublishSingleFile=true --self-contained
       - name: Build For Windows
-        run: dotnet publish --configuration Release --runtime win10-x64 --self-contained
+        run: dotnet publish -c Release -r win10-x64 -p PublishReadyToRun=true -p PublishSingleFile=true --self-contained
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}/bin/Release/net6.0


### PR DESCRIPTION
# Improvements
* Now the compilation processes of the interpreter take advantage of the `-p:PublishReadyToRun` and `-p:PublishSingleFile` options to generate a self-contained `.NET` application that is only composed of an .exe file and its respective `Debug` files.